### PR TITLE
[added] Add focusAfterRender prop

### DIFF
--- a/lib/components/Tray.js
+++ b/lib/components/Tray.js
@@ -11,7 +11,8 @@ export default React.createClass({
     onBlur: React.PropTypes.func,
     closeTimeoutMS: React.PropTypes.number,
     closeOnBlur: React.PropTypes.bool,
-    maintainFocus: React.PropTypes.bool
+    maintainFocus: React.PropTypes.bool,
+    focusAfterOpen: React.PropTypes.string
   },
 
   getDefaultProps() {

--- a/lib/components/TrayPortal.js
+++ b/lib/components/TrayPortal.js
@@ -57,7 +57,8 @@ export default React.createClass({
     closeOnBlur: PropTypes.bool,
     closeTimeoutMS: PropTypes.number,
     children: PropTypes.any,
-    maintainFocus: PropTypes.bool
+    maintainFocus: PropTypes.bool,
+    focusAfterOpen: PropTypes.string
   },
 
   getInitialState() {
@@ -85,7 +86,11 @@ export default React.createClass({
 
   componentDidUpdate() {
     if (this.focusAfterRender) {
-      this.focusContent();
+      if (this.props.focusAfterOpen) {
+        this.focusSelector(this.props.focusAfterOpen);
+      } else {
+        this.focusContent();
+      }
       this.setFocusAfterRender(false);
     }
   },
@@ -96,6 +101,12 @@ export default React.createClass({
 
   focusContent() {
     this.refs.content.focus();
+  },
+
+  focusSelector(querySelectorToUse) {
+    const el = document.querySelectorAll(querySelectorToUse);
+    const element = (el.length) ? el[0] : el;
+    element.focus();
   },
 
   handleOverlayClick(e) {

--- a/lib/components/__tests__/Tray-test.js
+++ b/lib/components/__tests__/Tray-test.js
@@ -110,4 +110,23 @@ describe('react-tray', function() {
       equal(document.activeElement, lastItem);
     });
   });
+
+  describe('focusAfterOpen prop', function() {
+    beforeEach(function(done) {
+      const props = {isOpen: true, onBlur: function() {}, closeTimeoutMS: 0, maintainFocus: true, focusAfterOpen: '#two'};
+      const children = (
+        <div>
+          <a href="#" id="one">One</a>
+          <a href="#" id="two">Two</a>
+          <a href="#" id="three">Three</a>
+        </div>
+      );
+      renderTray(props, children, () => done());
+    });
+
+    it('sends focus to the DOM node found via the selector passed in the prop', function() {
+      const secondItem = document.querySelector('#two');
+      equal(document.activeElement, secondItem);
+    });
+  });
 });


### PR DESCRIPTION
This makes it so if you provide focusAfterRender then that particular
element will be focused after the component renders instead of the
content of the tray.  This is handy to set focus to a close button
or some other arbitrary element within the content.
