### PR TITLE
'require' proper module names for 'react' and 'react-dom'

### DIFF
--- a/dist/react-tray.js
+++ b/dist/react-tray.js
@@ -1,10 +1,10 @@
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory(require("React"), require("ReactDOM"));
+		module.exports = factory(require("react"), require("react-dom"));
 	else if(typeof define === 'function' && define.amd)
-		define(["React", "ReactDOM"], factory);
+		define(["react", "react-dom"], factory);
 	else if(typeof exports === 'object')
-		exports["ReactTray"] = factory(require("React"), require("ReactDOM"));
+		exports["ReactTray"] = factory(require("react"), require("react-dom"));
 	else
 		root["ReactTray"] = factory(root["React"], root["ReactDOM"]);
 })(this, function(__WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_3__) {


### PR DESCRIPTION
I know this is a generated file but I could not find the original spot to change this. Can we change these 'require's so they pull in the right module? where would I do that? this will prevent us from needing the fallback in public/javascripts/ReactDOM.js in canvas-lms
